### PR TITLE
fix: coerce string boolean values for createNew in createProjectSchema

### DIFF
--- a/src/routes/projects/schemas.ts
+++ b/src/routes/projects/schemas.ts
@@ -4,7 +4,13 @@ import { z } from 'zod';
 export const createProjectSchema = z.object({
   name: z.string().min(1, 'Project name is required').max(255),
   path: z.string().min(1, 'Project path is required'),
-  createNew: z.boolean().optional(),
+  createNew: z.preprocess(
+    (val) => {
+      if (typeof val === 'string') return val === 'true';
+      return val;
+    },
+    z.boolean().optional(),
+  ),
 });
 
 export const updatePermissionsSchema = z.object({

--- a/test/unit/routes/projects/schemas.test.ts
+++ b/test/unit/routes/projects/schemas.test.ts
@@ -41,6 +41,34 @@ describe('Project Route Schemas', () => {
       const result = createProjectSchema.safeParse(valid);
       expect(result.success).toBe(true);
     });
+
+    it('should coerce string "false" to boolean false', () => {
+      const input = {
+        name: 'My Project',
+        path: '/home/user/projects/my-project',
+        createNew: 'false',
+      };
+
+      const result = createProjectSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.createNew).toBe(false);
+      }
+    });
+
+    it('should coerce string "true" to boolean true', () => {
+      const input = {
+        name: 'My Project',
+        path: '/home/user/projects/my-project',
+        createNew: 'true',
+      };
+
+      const result = createProjectSchema.safeParse(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.createNew).toBe(true);
+      }
+    });
   });
 
   describe('updatePermissionsSchema', () => {


### PR DESCRIPTION
When creating a project via POST /api/projects, some HTTP clients (e.g., certain browsers or form serializers) send the createNew field as the string "false" instead of the boolean false. The Zod schema z.boolean().optional() strictly rejects string values, causing a VALIDATION_ERROR with the message: createNew: Invalid input: expected boolean, received string.

This PR adds a z.preprocess() step that coerces string "true"/"false" to actual booleans before validation, matching the behavior already present in the request-validator.js middleware's validateBoolean() function.

